### PR TITLE
Move core fields to main form

### DIFF
--- a/gobk-volunteer-form.html
+++ b/gobk-volunteer-form.html
@@ -1,8 +1,8 @@
 <li class="control-group">
-  <input type="text" name="First name" placeholder="First Name" class=“required" />
+  <input type="text" name="First name" placeholder="First Name" class="required" />
   <input type="text" name="Last name" placeholder="Last Name" class="required" />
-  <input type="text" name="phone" placeholder="Phone" class=“required" />
-  <input type="text" name="zipcode" placeholder="Zip Code" class=“required" />
+  <input type="text" name="phone" placeholder="Phone" class="required" />
+  <input type="text" name="zipcode" placeholder="Zip Code" class="required" />
 </li>
 
 <center>

--- a/gobk-volunteer-form.html
+++ b/gobk-volunteer-form.html
@@ -1,8 +1,10 @@
 <li class="control-group">
-  <input type="text" name="First name" placeholder="First Name" class="required" />
-  <input type="text" name="Last name" placeholder="Last Name" class="required" />
+<!-- these are core fields on the main form:
+  <input type="text" name="answer[first_name]" placeholder="First Name" class="required" />
+  <input type="text" name="answer[last_name]" placeholder="Last Name" class="required" />
+  <input type="text" name="answer[zip_code]" placeholder="Zip Code" class="required" />
+-->
   <input type="text" name="phone" placeholder="Phone" class="required" />
-  <input type="text" name="zipcode" placeholder="Zip Code" class="required" />
 </li>
 
 <center>


### PR DESCRIPTION
Core fields like name don't get populated right in the activist unless they're added on the main form in the editor.  (They're here named `answer[first_name]` but that didn't seem to fully work for resubmission in a simple test.)  I've added them to the form editor and removed them from the custom html.